### PR TITLE
feature/add-audit-db-django

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.ht
 ## [0.3.0] - 2020-07-03
 ### Feature
 - [Configura el registro de logs con colores y agrega comandos shell para el uso del projecto.](https://github.com/saengate/djfullapp/pull/17)
-- [Agregar `Poetry` como manejador de paquetes en remplazo del `requirements.txt`.](https://github.com/saengate/djfullapp/pull/18)
+- [Agrega `Poetry` como manejador de paquetes en remplazo del `requirements.txt`.](https://github.com/saengate/djfullapp/pull/18)
+- [Agrega `django-easy-audit` como manejador de auditoria del proyecto.](https://github.com/saengate/djfullapp/pull/19)
 
 ## [0.2.0] - 2020-07-01
 ### Feature

--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ Solo debe tenerse cuidado en los contenedores si se cambian los puertos.
 * [Docker](https://docs.docker.com/engine/install/)
 * [Docker-composer](https://docs.docker.com/compose/install/)
 * [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
-* [poetry](https://pypi.org/project/poetry/)
 
 ### ¿Cómo instalar?
 
 Debes tener instalado docker y ansible en tu equipo, se dejan arriba los links para su instalación.
 Instalar Ansible sera necesario para modificar las contraseñas encryptadas.
+
+### Librerias de terceros
+
+[django-easy-audit](https://github.com/soynatan/django-easy-audit) Es una aplicación de auditoria de fácil uso que he incluido en este projecto. De momento, estará en evaluación y si cumple con las espectativas se volverá parte del proyecto. Todas las instrucciones de uso se encuentran en la descripción de dicho proyecto (Realmente parece que no requiere de ninguna interacción en los modelos, así que al ser prácticamente innecesaria la interacción del desarrollador para su ejecución se evita que por olvido no se monitoree algún modelo, simplemente genial).
+
 
 ## Desarrollo
 
@@ -70,6 +74,10 @@ INHABILITADA -tn
 -s   | --stop           detiene los contenedores                    (docker-compose down)
 ```
 
+### Librerias (pip requirements.txt y poetry)
+
+Este proyecto no usa directamente requirements para instalar el proyecto, en su lugar usa [poetry](https://pypi.org/project/poetry/) que generara el archivo durante la creación del contenedor y maneja efectivamente las versiones de las librerias. Se usa este metodo para aprovechar las ventajas de poetry y las ventajas de pip y descartar sus falencias. Revisa el archivo `pyproject.toml` para agregar las librerias, usa el siguiente link para entender como agregar la [versión](https://python-poetry.org/docs/dependency-specification/).
+
 ### Manejo de branch
 
 Uso git `hubflow` para el trabajo con las ramas
@@ -78,13 +86,25 @@ Para crear una nueva rama `git hf `TAG` start nombre-de-la-rama` recuerda que TA
 Para actualizar la rama y `develop` con los cambios que esten arriba ejecuta `git hf update`.
 Elimina la rama localmente y en github `git hf feature finish nombre-de-la-rama`.
 
-## Testing
+### Testing
 
 Se pueden ejecutar las pruebas de python usando el comando:
 ```sh
 ./cmd -tp | --tests_python
 ```
 Aún están por agregarse las pruebas en vue
+
+### Deploy de una nueva versión.
+
+Para generar una nueva versión, se debe crear un PR (con un título "Release X.Y.Z" con los valores que correspondan para X, Y y Z). Se debe seguir el estándar semver para determinar si se incrementa el valor de X (si hay cambios no retrocompatibles), Y (para mejoras retrocompatibles) o Z (si sólo hubo correcciones a bugs).
+
+En ese PR deben incluirse los siguientes cambios:
+
+Modificar el archivo `CHANGELOG.md` y `VERSION` para incluir una nueva entrada (al comienzo) para X.Y.Z que explique los cambios.
+Modificar el archivo `poetry.toml` para que la propiedad `"version"` apunte a la nueva versión X.Y.Z
+
+Luego de obtener aprobación del pull request, debe mezclarse a master e inmediatamente generar un release en GitHub con el tag X.Y.Z. En la descripción del release debes poner lo mismo que agregaste al changelog.
+
 
 ## Paso a producción
 
@@ -93,6 +113,7 @@ de ansible config-(contenedor).yml
 ```sh
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build
 ```
+
 
 ## Notas
 
@@ -115,7 +136,8 @@ el archivo .key dentro de la carpeta ansible si desea cambiar las contraseñas.
 En la configuración de ansible puede buscar la palabra ".key" y comentar la linea para que no busque
 la contraseña en un archivo y así asignar una contraseña nueva y guardarla en algún lugar seguro.
 
-## Error
+
+## Errores conocidos
 
 ### Supervisor
 
@@ -131,14 +153,3 @@ revisa el archivo en ansible template dentro del projecto o en /usr/local/bin/ru
 ```sh
 runsupervisor
 ```
-
-## Deploy de una nueva versión.
-
-Para generar una nueva versión, se debe crear un PR (con un título "Release X.Y.Z" con los valores que correspondan para X, Y y Z). Se debe seguir el estándar semver para determinar si se incrementa el valor de X (si hay cambios no retrocompatibles), Y (para mejoras retrocompatibles) o Z (si sólo hubo correcciones a bugs).
-
-En ese PR deben incluirse los siguientes cambios:
-
-Modificar el archivo `CHANGELOG.md` y `VERSION` para incluir una nueva entrada (al comienzo) para X.Y.Z que explique los cambios.
-Modificar el archivo `poetry.toml` para que la propiedad `"version"` apunte a la nueva versión X.Y.Z
-
-Luego de obtener aprobación del pull request, debe mezclarse a master e inmediatamente generar un release en GitHub con el tag X.Y.Z. En la descripción del release debes poner lo mismo que agregaste al changelog.

--- a/cmd
+++ b/cmd
@@ -13,30 +13,32 @@
 
 NC=`tput sgr0`
 GREEN=`tput setaf 2`
-BLUE=`tput setaf 4`
+CYAN=`tput setaf 6`
 
 help()
 {
-    echo "${BLUE}
+    echo "${CYAN}
     Ayuda: Comandos de ayuda para facilitar el uso del proyecto:
 
     -h | * | --help   muestran los comandos disponibles
 
-    -D   | --daemon         inciar el proyecto en background            (docker-compose up -d)
-    -DB  | --daemon_build   construye e incia el proyecto en background (docker-compose up --build -d)
-    -d   | --start          inciar el proyecto con verbose              (docker-compose up)
-    -db  | --start_build    construye e incia el proyecto con verbose   (docker-compose up --build)
-    -dl  | --docker_list    lista los contenedores por Imagen Estado y  (docker ps)
-                            Puestos
-    -p   | --shell_project  accede al contenedor del proyecto           (docker exec -it)
-    -tp  | --tests_python   entra al contenedor del proyecto y ejecuta  (docker exec -it.../manage.py test)
-                            los tests de Python
+    -D   | --daemon             inciar el proyecto en background            (docker-compose up -d)
+    -DB  | --daemon_build       construye e incia el proyecto en background (docker-compose up --build -d)
+    -d   | --start              inciar el proyecto con verbose              (docker-compose up)
+    -db  | --start_build        construye e incia el proyecto con verbose   (docker-compose up --build)
+    -dl  | --docker_list        lista los contenedores por Imagen Estado y  (docker ps)
+                                Puestos
+    -p   | --shell_project      accede al contenedor del proyecto           (docker exec -it)
+    -pt  | --tests_project      entra al contenedor del proyecto y ejecuta  (docker exec -it.../manage.py test)
+                                los tests de Python
+    -pm  | --proyect_migrate    ejecuta las migraciones en el proyecto      (docker exec -it...django-migrate)
+
     INHABILITADA -tn
-    -tn  | --tests_npm      entra al contenedor de vue y ejecuta        (docker exec -it...npm run test)
-                            los tests npm
-    -pg  | --shell_postgres accede al contenedor de PostgreSQL          (docker exec -it)
-    -neo | --shell_neo4j    accede al contenedor de Neo4j               (docker exec -it)
-    -s   | --stop           detiene los contenedores                    (docker-compose down)
+    -tn  | --tests_npm          entra al contenedor de vue y ejecuta        (docker exec -it...npm run test)
+                                los tests npm
+    -pg  | --shell_postgres     accede al contenedor de PostgreSQL          (docker exec -it)
+    -neo | --shell_neo4j        accede al contenedor de Neo4j               (docker exec -it)
+    -s   | --stop               detiene los contenedores                    (docker-compose down)
     ${NC}
     "
 }
@@ -69,7 +71,7 @@ start_build()
 docker_list()
 {
     echo "${GREEN}Lista los contenedores por Imagen Estado y Puestos${NC}";
-    docker ps --format "table {{.Image}}\t{{.Status}}\t{{.Ports}}";
+    docker ps --format "table {{.Names}}\t{{.ID}}\t{{.Status}}\t{{.Ports}}";
 }
 
 shell_project()
@@ -78,10 +80,17 @@ shell_project()
     docker exec -it djangofull /bin/bash;
 }
 
-tests_python()
+tests_project()
 {
     echo "${GREEN}Ejecutando los tests PYTHON del proyecto${NC}";
-    docker exec -it djangofull /bin/bash -c "poetry run python3 manage.py test";
+    docker exec -it djangofull /bin/bash -c "source /opt/venv/bin/activate && ./manage.py test";
+}
+
+proyect_migrate()
+{
+    echo "${GREEN}Ejecutando las migraciones DJANGO ${NC}";
+    echo "${RED}Recuerde que debe tener la base de datos funcionando ${NC}";
+    docker exec -it djangofull /bin/bash -c "django-migrate";
 }
 
 # Comentado hasta que se agregue la ejecución de tests en Vue
@@ -132,7 +141,10 @@ while [ "$1" != "" ]; do
         -p   | --shell_project )    shell_project
                                     exit
                                     ;;
-        -tp  | --tests_python )     tests_python
+        -pt  | --tests_project )    tests_project
+                                    exit
+                                    ;;
+        -pm  | --proyect_migrate )  proyect_migrate
                                     exit
                                     ;;
         -dl  | --docker_list )      docker_list

--- a/cmd-container-template
+++ b/cmd-container-template
@@ -20,12 +20,12 @@
 NC=`tput sgr0`
 RED=`tput setaf 1`
 GREEN=`tput setaf 2`
-BLUE=`tput setaf 4`
+CYAN=`tput setaf 6`
 env=
 
 help()
 {
-    echo "${BLUE}
+    echo "${CYAN}
     Ayuda: Comandos de ayuda para facilitar el uso del proyecto:
     Abre los puertos:
         $description_ports

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,3 +65,4 @@ services:
     environment:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
+    command: 'django-migrate'

--- a/project/ansible/roles/ansible-role-project/tasks/main.yml
+++ b/project/ansible/roles/ansible-role-project/tasks/main.yml
@@ -91,6 +91,7 @@
       - airflow-scheduler
       - airflow-server
       - airflow-queue
+      - django-migrate
       - cmdp
       - venvproject
       - runsupervisor

--- a/project/ansible/roles/ansible-role-project/templates/cmdp.j2
+++ b/project/ansible/roles/ansible-role-project/templates/cmdp.j2
@@ -15,7 +15,7 @@
 NC=`tput sgr0`
 RED=`tput setaf 1`
 GREEN=`tput setaf 2`
-BLUE=`tput setaf 4`
+CYAN=`tput setaf 4`
 
 restartsupervisor()
 {
@@ -40,12 +40,7 @@ createadmin()
 {
     echo "${GREEN}Creando administrador django${NC}";
     echo "${RED}Requiere que la base de datos este arriba${NC}";
-    source {{ path_venv }}/bin/activate;
-    cd /webapps/project;
-    ./manage.py makemigrations;
-    ./manage.py migrate;
-    ./manage.py collectstatic;
-    ./python manage.py install_labels;
+    django-migrate;
     echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('{{django_user}}', '{{django_email}}', '{{django_password}}')" | ./manage.py shell;
 
 }
@@ -70,7 +65,7 @@ logwebsocket()
 
 help()
 {
-    echo "${BLUE}
+    echo "${CYAN}
     Ayuda: Comandos de ayuda para facilitar el uso del proyecto dentro del contenedor:
 
     -h  | * | --help   muestran los comandos disponibles

--- a/project/ansible/roles/ansible-role-project/templates/django-migrate.j2
+++ b/project/ansible/roles/ansible-role-project/templates/django-migrate.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+#-*- ENCODING: UTF-8 -*-
+
+main()
+{
+    source {{ path_venv }}/bin/activate;
+    cd /webapps/project;
+    ./manage.py makemigrations;
+    ./manage.py migrate;
+    ./manage.py collectstatic;
+    ./python manage.py install_labels;
+}
+
+main

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'channels',
     'django_neomodel',
+    'easyaudit',
     'ses',
 ]
 
@@ -58,6 +59,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'easyaudit.middleware.easyaudit.EasyAuditMiddleware',
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -220,3 +222,31 @@ LOGGING = {
         },
     },
 }
+
+
+# AUDIT [django-easy-audit](https://github.com/soynatan/django-easy-audit)
+
+DJANGO_EASY_AUDIT_WATCH_MODEL_EVENTS = True
+DJANGO_EASY_AUDIT_WATCH_AUTH_EVENTS = True
+DJANGO_EASY_AUDIT_WATCH_REQUEST_EVENTS = True
+
+# DJANGO_EASY_AUDIT_UNREGISTERED_CLASSES_EXTRA = ['app_name.model_name']
+# DJANGO_EASY_AUDIT_UNREGISTERED_URLS_EXTRA = ['url']
+# DJANGO_EASY_AUDIT_CRUD_DIFFERENCE_CALLBACKS = ['string-paths-to-functions-classes']
+
+# This is reserved for future use (does not do anything yet) 1.2.2
+# DJANGO_EASY_AUDIT_USER_DB_CONSTRAINT = 'default'
+
+# DJANGO_EASY_AUDIT_CRUD_EVENT_LIST_FILTER = ['event_type', 'content_type', 'user', 'datetime', ] 
+# DJANGO_EASY_AUDIT_LOGIN_EVENT_LIST_FILTER = ['login_type', 'user', 'datetime', ]
+# DJANGO_EASY_AUDIT_REQUEST_EVENT_LIST_FILTER = ['method', 'user', 'datetime', ]
+
+# DJANGO_EASY_AUDIT_DATABASE_ALIAS = 'default '
+
+# No guarda auditoria si no han ocurrido cambios
+DJANGO_EASY_AUDIT_CRUD_EVENT_NO_CHANGED_FIELDS_SKIP = True
+
+# Solo lectura impide que un superusuario los modifique
+DJANGO_EASY_AUDIT_READONLY_EVENTS = True
+
+# DJANGO_EASY_AUDIT_LOGGING_BACKEND = 'easyaudit.backends.ModelBackend'

--- a/project/pyproject.toml
+++ b/project/pyproject.toml
@@ -41,4 +41,5 @@ psycopg2 = "^2.8"
 celery = "^4.4"
 apache-airflow = { version = "^1.10", extras = [ "postgres", "celery", "redis", "crypto" ] }
 django_neomodel = "*"
-termcolor = "^1.1.0"
+termcolor = "^1.1"
+django-easy-audit = "^1.2"


### PR DESCRIPTION
Agrega un auditor para el projecto

- Agrega [django-easy-audit](https://github.com/soynatan/django-easy-audit) al proyecto para tener una manera de monitorear los cambios en los modelos. Según la documentación, esta es la forma más sencilla de agregar un auditor sin necesidad de agregar código adicional a los modelos evitando que se omita por olvido.